### PR TITLE
Fix CLI output and search cache bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Aut_Sci_Write/
 │   ├── sci-search/           # Paper search with journal metrics
 │   └── sci-zotero/           # Zotero library integration
 ├── scripts/
-│   ├── sci_search.py         # Search core logic
+│   ├── sci-search/
+│   │   └── sci_search.py     # Search core logic
 │   ├── extract_core_insights.py
 │   ├── zotero.py
 │   └── journal_db.json       # Journal metrics database (independently updatable)
@@ -274,7 +275,8 @@ Aut_Sci_Write/
 │   ├── sci-search/           # 文献检索与期刊指标
 │   └── sci-zotero/           # Zotero 文献库集成
 ├── scripts/
-│   ├── sci_search.py         # 检索核心逻辑
+│   ├── sci-search/
+│   │   └── sci_search.py     # 检索核心逻辑
 │   ├── extract_core_insights.py
 │   ├── zotero.py
 │   └── journal_db.json       # 期刊指标数据库（可独立更新）

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyMuPDF
 pdfplumber
 numpy
+opencv-python
+Pillow
+pytesseract

--- a/scripts/extract_core_insights.py
+++ b/scripts/extract_core_insights.py
@@ -9,7 +9,7 @@ Version: 1.0
 import sys
 import json
 import re
-import os
+import csv
 from pathlib import Path
 from datetime import datetime
 import argparse
@@ -20,13 +20,197 @@ if sys.platform == 'win32':
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
 
-try:
-    import fitz  # PyMuPDF
-    import pdfplumber
-except ImportError:
-    print("Error: Required libraries not installed")
-    print("Install with: pip install PyMuPDF pdfplumber")
-    sys.exit(1)
+OUTPUT_EXTENSIONS = {
+    'json': '.json',
+    'markdown': '.md',
+    'csv': '.csv',
+}
+
+CONFIDENCE_COLUMNS = [
+    ('research_problem', 'Problem_Conf'),
+    ('methodology', 'Method_Conf'),
+    ('key_results', 'Results_Conf'),
+    ('innovation', 'Innovation_Conf'),
+    ('application', 'Application_Conf'),
+    ('limitations', 'Limitations_Conf'),
+]
+
+
+def ensure_pdf_dependencies():
+    """Import heavy PDF dependencies lazily so --help still works."""
+    try:
+        import fitz  # PyMuPDF
+        import pdfplumber
+    except ImportError as exc:
+        raise RuntimeError(
+            "Required libraries not installed. Install with: "
+            "pip install PyMuPDF pdfplumber"
+        ) from exc
+    return fitz, pdfplumber
+
+
+def default_output_path(input_path, output_format):
+    suffix = OUTPUT_EXTENSIONS[output_format]
+    return str(Path(input_path).with_name(f"{Path(input_path).stem}_insights{suffix}"))
+
+
+def stringify_insight(value):
+    """Render insight fields consistently across scalar/list forms."""
+    if isinstance(value, list):
+        return ' | '.join(value)
+    return value
+
+
+def format_result_as_markdown(result):
+    """Render a single extraction result as readable markdown."""
+    meta = result.get('metadata', {})
+    insights = result.get('core_insights', {})
+    scores = result.get('confidence_scores', {})
+
+    lines = [
+        f"# Core Insights: {meta.get('title') or 'Unknown Title'}",
+        "",
+        "## Metadata",
+        f"- **Authors:** {', '.join(meta.get('authors', [])) or 'Unknown'}",
+        f"- **Journal:** {meta.get('journal') or 'Unknown'}",
+        f"- **Year:** {meta.get('year') or 'Unknown'}",
+        f"- **DOI:** {meta.get('doi') or 'N/A'}",
+        f"- **Status:** {result.get('status', 'unknown')}",
+        f"- **Extraction Time:** {result.get('extraction_time', 0)}s",
+        "",
+        "## Core Insights",
+    ]
+
+    labels = {
+        'research_problem': 'Research Problem',
+        'methodology': 'Methodology',
+        'key_results': 'Key Results',
+        'innovation': 'Innovation',
+        'application': 'Application',
+        'limitations': 'Limitations',
+    }
+
+    for key, label in labels.items():
+        value = insights.get(key, 'Not found')
+        if isinstance(value, list):
+            rendered = '\n'.join(f"  - {item}" for item in value)
+        else:
+            rendered = f"  - {value}"
+        lines.append(f"### {label}")
+        lines.append(rendered)
+        lines.append(f"  - Confidence: {scores.get(key, 0.0):.2f}")
+        lines.append("")
+
+    if result.get('status') == 'error':
+        lines.extend([
+            "## Error",
+            f"- **Kind:** {result.get('error_kind', 'unknown')}",
+            f"- **Detail:** {result.get('error_detail', 'N/A')}",
+            f"- **Suggestion:** {result.get('suggestion', 'N/A')}",
+            "",
+        ])
+
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def write_result_file(result, output_file, output_format):
+    """Persist a single result in the requested format."""
+    path = Path(output_file)
+    if output_format == 'json':
+        with path.open('w', encoding='utf-8') as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+        return path
+
+    if output_format == 'markdown':
+        path.write_text(format_result_as_markdown(result), encoding='utf-8')
+        return path
+
+    meta = result.get('metadata', {})
+    scores = result.get('confidence_scores', {})
+    insights = result.get('core_insights', {})
+
+    with path.open('w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'Title', 'Authors', 'Journal', 'Year',
+            'Research_Problem', 'Methodology', 'Key_Results',
+            'Innovation', 'Application', 'Limitations',
+            'Problem_Conf', 'Method_Conf', 'Results_Conf',
+            'Innovation_Conf', 'Application_Conf', 'Limitations_Conf',
+            'Status', 'Time(s)'
+        ])
+        writer.writerow([
+            meta.get('title', ''),
+            '; '.join(meta.get('authors', [])),
+            meta.get('journal', ''),
+            meta.get('year', ''),
+            stringify_insight(insights.get('research_problem', '')),
+            stringify_insight(insights.get('methodology', '')),
+            stringify_insight(insights.get('key_results', '')),
+            stringify_insight(insights.get('innovation', '')),
+            stringify_insight(insights.get('application', '')),
+            stringify_insight(insights.get('limitations', '')),
+            f"{scores.get('research_problem', 0):.2f}",
+            f"{scores.get('methodology', 0):.2f}",
+            f"{scores.get('key_results', 0):.2f}",
+            f"{scores.get('innovation', 0):.2f}",
+            f"{scores.get('application', 0):.2f}",
+            f"{scores.get('limitations', 0):.2f}",
+            result.get('status', ''),
+            result.get('extraction_time', 0),
+        ])
+    return path
+
+
+def write_batch_summary(results, output_dir, output_format):
+    """Write a batch summary in the selected format."""
+    output_dir = Path(output_dir)
+    suffix = OUTPUT_EXTENSIONS[output_format]
+    output_file = output_dir / f"summary{suffix}"
+
+    if output_format == 'json':
+        with output_file.open('w', encoding='utf-8') as f:
+            json.dump(results, f, ensure_ascii=False, indent=2)
+        return output_file
+
+    if output_format == 'markdown':
+        lines = ["# Batch Core Insights Summary", ""]
+        for index, result in enumerate(results, 1):
+            meta = result.get('metadata', {})
+            lines.extend([
+                f"## {index}. {meta.get('title') or 'Unknown Title'}",
+                f"- **Status:** {result.get('status', 'unknown')}",
+                f"- **Journal:** {meta.get('journal') or 'Unknown'}",
+                f"- **Year:** {meta.get('year') or 'Unknown'}",
+                f"- **Research Problem:** {stringify_insight(result.get('core_insights', {}).get('research_problem', 'Not found'))}",
+                f"- **Methodology:** {stringify_insight(result.get('core_insights', {}).get('methodology', 'Not found'))}",
+                "",
+            ])
+        output_file.write_text('\n'.join(lines).rstrip() + '\n', encoding='utf-8')
+        return output_file
+
+    with output_file.open('w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'Title', 'Authors', 'Journal', 'Year',
+            *[column for _, column in CONFIDENCE_COLUMNS],
+            'Status', 'Time(s)'
+        ])
+
+        for result in results:
+            meta = result.get('metadata', {})
+            scores = result.get('confidence_scores', {})
+            writer.writerow([
+                meta.get('title', ''),
+                '; '.join(meta.get('authors', [])),
+                meta.get('journal', ''),
+                meta.get('year', ''),
+                *[f"{scores.get(key, 0):.2f}" for key, _ in CONFIDENCE_COLUMNS],
+                result.get('status', ''),
+                result.get('extraction_time', 0),
+            ])
+
+    return output_file
 
 
 class CoreInsightsExtractor:
@@ -95,7 +279,9 @@ class CoreInsightsExtractor:
     
     def _extract_text_and_metadata(self, pdf_path):
         """Extract text and metadata from PDF"""
+        doc = None
         try:
+            fitz, pdfplumber = ensure_pdf_dependencies()
             # Use PyMuPDF for metadata
             doc = fitz.open(pdf_path)
             metadata = doc.metadata or {}
@@ -105,9 +291,7 @@ class CoreInsightsExtractor:
             with pdfplumber.open(pdf_path) as pdf:
                 for page in pdf.pages:
                     text += page.extract_text() or ""
-            
-            doc.close()
-            
+
             # Parse metadata
             parsed_metadata = {
                 'title': metadata.get('title', 'Unknown'),
@@ -120,10 +304,15 @@ class CoreInsightsExtractor:
             
             return text, parsed_metadata
             
+        except RuntimeError:
+            raise
         except Exception as e:
             if self.verbose:
                 print(f"Error extracting text: {e}")
-            return "", {}
+            raise
+        finally:
+            if doc is not None:
+                doc.close()
     
     def _extract_authors(self, text):
         """Extract author names from text"""
@@ -382,7 +571,7 @@ class CoreInsightsExtractor:
             'suggestion': suggestions.get(error_kind, suggestions['unknown']),
         }
     
-    def batch_process(self, folder_path, output_dir=None, workers=4):
+    def batch_process(self, folder_path, output_dir=None, workers=4, summary_format='csv'):
         """Process multiple PDFs in parallel using a thread pool.
 
         workers=4 is a safe default: extraction is I/O-bound (disk + PDF
@@ -397,7 +586,7 @@ class CoreInsightsExtractor:
 
         if not pdf_files:
             print(f"No PDF files found in {folder_path}")
-            return
+            return []
 
         if output_dir is None:
             output_dir = folder / 'insights'
@@ -431,48 +620,13 @@ class CoreInsightsExtractor:
                     print(f"  [{completed[0]}/{total}] {name} "
                           f"✓ ({result['extraction_time']}s)")
 
-        # Generate summary CSV after all workers finish.
-        self._generate_summary_csv(results, output_dir / 'summary.csv')
+        summary_path = write_batch_summary(results, output_dir, summary_format)
 
         print(f"\n✓ Processed {total} PDFs")
         print(f"✓ Results saved to {output_dir}")
+        print(f"✓ Summary saved to {summary_path}")
 
         return results
-    
-    def _generate_summary_csv(self, results, output_file):
-        """Generate CSV summary of all results"""
-        import csv
-        
-        with open(output_file, 'w', newline='', encoding='utf-8') as f:
-            writer = csv.writer(f)
-            
-            # Header
-            writer.writerow([
-                'Title', 'Authors', 'Journal', 'Year',
-                'Problem_Conf', 'Method_Conf', 'Results_Conf',
-                'Innovation_Conf', 'Application_Conf', 'Limitations_Conf',
-                'Status', 'Time(s)'
-            ])
-            
-            # Data rows
-            for result in results:
-                meta = result.get('metadata', {})
-                scores = result.get('confidence_scores', {})
-                
-                writer.writerow([
-                    meta.get('title', ''),
-                    '; '.join(meta.get('authors', [])),
-                    meta.get('journal', ''),
-                    meta.get('year', ''),
-                    f"{scores.get('problem', 0):.2f}",
-                    f"{scores.get('methodology', 0):.2f}",
-                    f"{scores.get('results', 0):.2f}",
-                    f"{scores.get('innovation', 0):.2f}",
-                    f"{scores.get('application', 0):.2f}",
-                    f"{scores.get('limitations', 0):.2f}",
-                    result.get('status', ''),
-                    result.get('extraction_time', 0)
-                ])
 
 
 def main():
@@ -481,15 +635,25 @@ def main():
     parser.add_argument('--batch', action='store_true', help='Process all PDFs in folder')
     parser.add_argument('--output', help='Output directory or file')
     parser.add_argument('--format', choices=['json', 'markdown', 'csv'], default='json', help='Output format')
+    parser.add_argument('--workers', type=int, default=4, help='Parallel workers for batch mode')
     parser.add_argument('--verbose', action='store_true', help='Verbose output')
     
     args = parser.parse_args()
     
+    if args.workers < 1:
+        parser.error('--workers must be >= 1')
+
+    try:
+        ensure_pdf_dependencies()
+    except RuntimeError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
     extractor = CoreInsightsExtractor(verbose=args.verbose)
     
     if args.batch:
         # Batch processing
-        results = extractor.batch_process(args.input, args.output)
+        extractor.batch_process(args.input, args.output, workers=args.workers, summary_format=args.format)
     else:
         # Single file processing
         result = extractor.extract_from_pdf(args.input)
@@ -498,10 +662,9 @@ def main():
         if args.output:
             output_file = args.output
         else:
-            output_file = Path(args.input).stem + '_insights.json'
-        
-        with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(result, f, ensure_ascii=False, indent=2)
+            output_file = default_output_path(args.input, args.format)
+
+        write_result_file(result, output_file, args.format)
         
         print(f"✓ Insights saved to {output_file}")
         print(f"✓ Status: {result['status']}")

--- a/skills/sci-search/SKILL.md
+++ b/skills/sci-search/SKILL.md
@@ -57,15 +57,15 @@ The **WoS Starter API** is free to apply for and provides access to the Web of S
 
 ## Usage
 
-Main script: `../../scripts/sci_search.py`
+Main script: `./sci_search.py`
 
 ```bash
 # Search all sources (arXiv + PubMed + WoS if key set)
-python scripts/sci_search.py "perovskite solar cells" --limit 5
+python skills/sci-search/sci_search.py "perovskite solar cells" --limit 5
 
 # Search Web of Science only
-python scripts/sci_search.py "solid state electrolyte" --source wos --limit 10
+python skills/sci-search/sci_search.py "solid state electrolyte" --source wos --limit 10
 
 # Export results to markdown
-python scripts/sci_search.py "graphene battery" --output results.md
+python skills/sci-search/sci_search.py "graphene battery" --output results.md
 ```

--- a/skills/sci-search/sci_search.py
+++ b/skills/sci-search/sci_search.py
@@ -26,12 +26,13 @@ if sys.platform == 'win32':
 # Configuration
 _SCRIPT_DIR = Path(__file__).parent
 LIBRARY_PATH = _SCRIPT_DIR / "library.json"
+JOURNAL_DB_PATH = _SCRIPT_DIR.parent.parent / "scripts" / "journal_db.json"
 
 # API rate-limit delay (seconds)
 RATE_LIMIT_DELAY = 1.0
 
-# Journal metrics database (from smart_paper_output.py)
-JOURNAL_DB = {
+# Journal metrics database fallback (overridden by journal_db.json when present)
+DEFAULT_JOURNAL_DB = {
     'Advanced Materials': {
         'jcr_partition': 'Q1',
         'impact_factor': '29.4',
@@ -210,6 +211,55 @@ JOURNAL_DB = {
     }
 }
 
+
+def _normalize_journal_metrics(journal_name: str, metrics: Dict) -> Dict:
+    """Support both legacy JSON schema and richer in-code metrics schema."""
+    normalized = {
+        'jcr_partition': metrics.get('jcr_partition', metrics.get('JCR', 'N/A')),
+        'impact_factor': str(metrics.get('impact_factor', metrics.get('IF', 'N/A'))),
+        '5_year_if': str(metrics.get('5_year_if', metrics.get('IF', 'N/A'))),
+        'chinese_partition': metrics.get('chinese_partition', metrics.get('Partition', 'N/A')),
+        'category': metrics.get('category', ''),
+        'publisher': metrics.get('publisher', metrics.get('Publisher', '')),
+        'is_top_journal': bool(metrics.get('is_top_journal', False)),
+        'is_nature_science_advmat': bool(metrics.get('is_nature_science_advmat', False)),
+        'notes': metrics.get('notes', ''),
+    }
+
+    journal_lower = journal_name.lower()
+    if journal_lower in {'nature', 'science'} or 'advanced materials' in journal_lower:
+        normalized['is_top_journal'] = True
+        normalized['is_nature_science_advmat'] = True
+
+    return normalized
+
+
+def load_journal_db(db_path: Path = JOURNAL_DB_PATH) -> Dict[str, Dict]:
+    """Load journal metrics from disk, falling back to bundled defaults."""
+    database = {
+        name: _normalize_journal_metrics(name, metrics)
+        for name, metrics in DEFAULT_JOURNAL_DB.items()
+    }
+
+    if not db_path.exists():
+        return database
+
+    try:
+        with db_path.open('r', encoding='utf-8') as f:
+            file_metrics = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Warning: failed to load journal DB from {db_path}: {exc}")
+        return database
+
+    for name, metrics in file_metrics.items():
+        if isinstance(metrics, dict):
+            database[name] = _normalize_journal_metrics(name, metrics)
+
+    return database
+
+
+JOURNAL_DB = load_journal_db()
+
 def get_journal_metrics(journal_name: str) -> Optional[Dict]:
     if not journal_name:
         return None
@@ -261,18 +311,39 @@ class PaperLibrary:
 
     def _save_library(self):
         data = {'papers': self.papers, 'last_updated': datetime.now().isoformat()}
+        Path(self.library_path).parent.mkdir(parents=True, exist_ok=True)
         with open(self.library_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
 
+    def _paper_key(self, paper: Dict) -> tuple:
+        return (
+            paper.get('source', ''),
+            paper.get('url', ''),
+            paper.get('doi', ''),
+            paper.get('title', '').strip().lower(),
+        )
+
     def add_paper(self, paper: Dict):
         # Decorate with metrics if available
+        paper = dict(paper)
         if paper.get('journal'):
             metrics = get_journal_metrics(paper['journal'])
             if metrics:
                 paper['journal_metrics'] = metrics
 
+        paper_key = self._paper_key(paper)
+        for index, existing in enumerate(self.papers):
+            if self._paper_key(existing) == paper_key:
+                self.papers[index] = paper
+                self._save_library()
+                return
+
         self.papers.append(paper)
         self._save_library()
+
+    def extend_papers(self, papers: List[Dict]):
+        for paper in papers:
+            self.add_paper(paper)
 
 class ArxivFetcher:
     API_URL = "https://export.arxiv.org/api/query"
@@ -444,6 +515,26 @@ def format_markdown(paper: Dict, index: int) -> str:
 
     return "\n".join(lines)
 
+
+def dedupe_results(results: List[Dict]) -> List[Dict]:
+    """Deduplicate cross-source results while keeping first-seen order."""
+    seen = set()
+    deduped = []
+
+    for paper in results:
+        key = (
+            paper.get('source', ''),
+            paper.get('url', ''),
+            paper.get('doi', ''),
+            paper.get('title', '').strip().lower(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(paper)
+
+    return deduped
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description='Sci Search Tool')
@@ -452,6 +543,8 @@ def main():
     parser.add_argument('--output', help='Output to markdown file')
     parser.add_argument('--source', choices=['all', 'arxiv', 'pubmed', 'wos'], default='all',
                         help='Search source (default: all available)')
+    parser.add_argument('--library', default=str(LIBRARY_PATH), help='Path to library cache JSON')
+    parser.add_argument('--no-cache', action='store_true', help='Skip writing search results to library cache')
     args = parser.parse_args()
 
     results = []
@@ -479,9 +572,15 @@ def main():
         else:
             print("  ⚠ Web of Science skipped (WOS_API_KEY not set)")
 
+    results = dedupe_results(results)
+
     if not results:
         print("No results found.")
         return
+
+    if not args.no_cache:
+        PaperLibrary(args.library).extend_papers(results)
+        print(f"Cached {len(results)} result(s) to {args.library}")
 
     md_output = [f"# Search Results: {args.query}\n"]
     for i, p in enumerate(results, 1):

--- a/tests/test_extract_core_insights.py
+++ b/tests/test_extract_core_insights.py
@@ -1,0 +1,111 @@
+import csv
+import contextlib
+import importlib.util
+import io
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "extract_core_insights.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("extract_core_insights", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class ExtractCoreInsightsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_module()
+
+    def sample_result(self):
+        return {
+            "metadata": {
+                "title": "A Test Paper",
+                "authors": ["Ada Lovelace", "Grace Hopper"],
+                "journal": "Nature",
+                "year": 2025,
+                "doi": "10.1000/test",
+            },
+            "core_insights": {
+                "research_problem": "Improve scientific extraction quality.",
+                "methodology": "A heuristic extraction pipeline.",
+                "key_results": ["Accuracy improved by 12.3%."],
+                "innovation": ["Lazy dependency loading for CLI UX."],
+                "application": "CLI workflows and batch review.",
+                "limitations": ["OCR-heavy PDFs remain difficult."],
+            },
+            "confidence_scores": {
+                "research_problem": 0.90,
+                "methodology": 0.70,
+                "key_results": 0.80,
+                "innovation": 0.60,
+                "application": 0.50,
+                "limitations": 0.40,
+            },
+            "extraction_time": 3,
+            "status": "success",
+        }
+
+    def test_help_runs_without_pdf_dependencies(self):
+        result = subprocess.run(
+            [sys.executable, str(MODULE_PATH), "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--format", result.stdout)
+        self.assertIn("--workers", result.stdout)
+
+    def test_write_result_file_csv_uses_real_confidence_keys(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = Path(tmp_dir) / "paper.csv"
+            self.module.write_result_file(
+                self.sample_result(),
+                output_path,
+                "csv",
+            )
+
+            with output_path.open("r", encoding="utf-8", newline="") as f:
+                rows = list(csv.DictReader(f))
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["Problem_Conf"], "0.90")
+        self.assertEqual(rows[0]["Results_Conf"], "0.80")
+
+    def test_batch_process_writes_requested_summary_format(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pdf_dir = Path(tmp_dir) / "pdfs"
+            output_dir = Path(tmp_dir) / "out"
+            pdf_dir.mkdir()
+            (pdf_dir / "paper1.pdf").write_bytes(b"%PDF-1.4")
+
+            extractor = self.module.CoreInsightsExtractor()
+            extractor.extract_from_pdf = lambda _path: self.sample_result()
+            with contextlib.redirect_stdout(io.StringIO()):
+                results = extractor.batch_process(
+                    pdf_dir,
+                    output_dir=output_dir,
+                    workers=1,
+                    summary_format="markdown",
+                )
+
+            summary_path = output_dir / "summary.md"
+            summary_text = summary_path.read_text(encoding="utf-8")
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("Batch Core Insights Summary", summary_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sci_search.py
+++ b/tests/test_sci_search.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "skills" / "sci-search" / "sci_search.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("sci_search", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class SciSearchTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.module = load_module()
+
+    def test_load_journal_db_normalizes_external_schema(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "journal_db.json"
+            db_path.write_text(
+                json.dumps(
+                    {
+                        "Custom Journal": {
+                            "JCR": "Q2",
+                            "IF": 5.5,
+                            "Partition": "材料科学2区",
+                            "Publisher": "Test Publisher",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            journal_db = self.module.load_journal_db(db_path)
+
+        self.assertIn("Custom Journal", journal_db)
+        self.assertEqual(journal_db["Custom Journal"]["jcr_partition"], "Q2")
+        self.assertEqual(journal_db["Custom Journal"]["impact_factor"], "5.5")
+        self.assertEqual(journal_db["Custom Journal"]["publisher"], "Test Publisher")
+
+    def test_paper_library_deduplicates_and_updates_entries(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            library_path = Path(tmp_dir) / "library.json"
+            library = self.module.PaperLibrary(str(library_path))
+            first = {
+                "source": "pubmed",
+                "title": "A Useful Paper",
+                "authors": ["A. Author"],
+                "year": "2025",
+                "journal": "Nature",
+                "url": "https://pubmed.ncbi.nlm.nih.gov/1/",
+                "doi": "10.1000/example",
+                "abstract": "old abstract",
+            }
+            updated = dict(first, abstract="new abstract")
+
+            library.add_paper(first)
+            library.add_paper(updated)
+
+            saved = json.loads(library_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(len(library.papers), 1)
+        self.assertEqual(library.papers[0]["abstract"], "new abstract")
+        self.assertEqual(saved["papers"][0]["abstract"], "new abstract")
+
+    def test_dedupe_results_preserves_first_seen_order(self):
+        first = {
+            "source": "arxiv",
+            "title": "Paper A",
+            "url": "https://arxiv.org/abs/1",
+            "doi": "",
+        }
+        duplicate = dict(first, journal="Nature")
+        second = {
+            "source": "pubmed",
+            "title": "Paper B",
+            "url": "https://pubmed.ncbi.nlm.nih.gov/2/",
+            "doi": "10.1000/b",
+        }
+
+        deduped = self.module.dedupe_results([first, duplicate, second])
+
+        self.assertEqual([paper["title"] for paper in deduped], ["Paper A", "Paper B"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `extract_core_insights.py` so `--help` works without PDF dependencies, `--format` actually controls output, and batch summaries use the correct confidence keys
- restore `sci-search` on the current code layout by loading `scripts/journal_db.json`, deduplicating cached papers, and adding cache controls alongside the existing `--source` / WoS support
- add regression tests for extraction formatting and search caching, and document the current sci-search entrypoint

## Testing
- python3 -m unittest discover -s tests -v
- python3 scripts/extract_core_insights.py --help
- python3 skills/sci-search/sci_search.py --help